### PR TITLE
Start code server on https:// tunnel.

### DIFF
--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -38,7 +38,7 @@ class ColabCode:
         for tunnel in active_tunnels:
             public_url = tunnel.public_url
             ngrok.disconnect(public_url)
-        url = ngrok.connect(port=self.port)
+        url = ngrok.connect(port=self.port, options={"bind_tls": True})
         print(f"Code Server can be accessed on: {url}")
 
     def _run_code(self):


### PR DESCRIPTION
Start https:// tunnel. 
It allows use all code server features: install code as a usual app in the desktop environment, use clipboard sharing...