### PR TITLE
add kaggle starter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ $ ColabCode(port=10000, password="abhishek", mount_drive=True)
 ## How to use it?
 Colab starter notebook: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/abhishekkrthakur/colabcode/blob/master/colab_starter.ipynb)
 
+Kaggle starter notebook: [![Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://www.kaggle.com/kernels/fork-version/43820352)
+
 `ColabCode` comes pre-installed with some VS Code extensions.
 
 ##### See an example in youtube video     [![YouTube Video](https://img.shields.io/youtube/views/7kTbM3D02jU?style=social)](https://youtu.be/7kTbM3D02jU)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ required arguments:
 
 optional arguments:
   --password PASSWORD  password to protect your code-server from unauthorized access
-  --mount_drive        if you use --mount_drive, your google drive will be mounted
+  --mount_drive        if you use --mount_drive, your google drive will be mounted (Only in colab)
 ```
 
 Else, you can do the following:
@@ -49,7 +49,7 @@ $ ColabCode()
 # ColabCode has the following arguments:
 # - port: the port you want to run code-server on, default 10000
 # - password: password to protect your code server from being accessed by someone else. Note that there is no password by default!
-# - mount_drive: True or False to mount your Google Drive
+# - mount_drive: True or False to mount your Google Drive (Only in colab)
 
 $ ColabCode(port=10000, password="abhishek", mount_drive=True)
 ```

--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -43,8 +43,11 @@ class ColabCode:
 
     def _run_code(self):
         os.system(f"fuser -n tcp -k {self.port}")
-        if self._mount and colab_env:
-            drive.mount("/content/drive")
+        if self._mount:
+            if colab_env:
+                drive.mount("/content/drive")
+            else:
+                print("Mounting drive is supported only in colab")
         if self.password:
             code_cmd = f"PASSWORD={self.password} code-server --port {self.port} --disable-telemetry"
         else:

--- a/scripts/colabcode
+++ b/scripts/colabcode
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     optional.add_argument(
         "--mount_drive",
         action="store_true",
-        help="if you use --mount_drive, your google drive will be mounted",
+        help="if you use --mount_drive, your google drive will be mounted(Only in colab)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Changes:

-  Fixed logic for mounting Google drive outside Colab.
-  Added Kaggle starter notebook edit link with `Open in Kaggle`  badge. 
