### PR TITLE
Code server patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ required arguments:
 optional arguments:
   --password PASSWORD  password to protect your code-server from unauthorized access
   --mount_drive        if you use --mount_drive, your google drive will be mounted
+  --code_server   code server version you want to use default is the latest
 ```
 
 Else, you can do the following:
@@ -50,13 +51,16 @@ $ ColabCode()
 # - port: the port you want to run code-server on, default 10000
 # - password: password to protect your code server from being accessed by someone else. Note that there is no password by default!
 # - mount_drive: True or False to mount your Google Drive
-
-$ ColabCode(port=10000, password="abhishek", mount_drive=True)
+# - code_server: code server version in the form X.X.X , default latest
+$ ColabCode(port=10000, password="abhishek", mount_drive=True, code_server=3.6.0)
 ```
 ## How to use it?
 Colab starter notebook: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/abhishekkrthakur/colabcode/blob/master/colab_starter.ipynb)
 
 `ColabCode` comes pre-installed with some VS Code extensions.
+
+You can find code server release versions [here](https://github.com/cdr/code-server/releases).
+>Do note you may find some versions not working, so skip them.
 
 ##### See an example in youtube video     [![YouTube Video](https://img.shields.io/youtube/views/7kTbM3D02jU?style=social)](https://youtu.be/7kTbM3D02jU)
 

--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -29,10 +29,10 @@ class ColabCode:
         subprocess.run(
             ["wget", "https://code-server.dev/install.sh"], stdout=subprocess.PIPE
         )
-        if self._code_server = 'latest':
+        if self._code_server == 'latest':
             subprocess.run(["sh", "install.sh"], stdout=subprocess.PIPE)
         else:
-            subprocess.run(["sh", "install.sh", "--version", str(self._code_server)], stdout=subprocess.PIPE)
+            subprocess.run(["sh", "install.sh", "--version", f"{self._code_server}"], stdout=subprocess.PIPE)
             
 
     def _install_extensions(self):

--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -14,21 +14,26 @@ EXTENSIONS = ["ms-python.python", "ms-toolsai.jupyter"]
 
 
 class ColabCode:
-    def __init__(self, port=10000, password=None, authtoken=None, mount_drive=False):
+    def __init__(self, port=10000, password=None, authtoken=None, mount_drive=False, code_server='latest'):
         self.port = port
         self.password = password
         self.authtoken = authtoken
         self._mount = mount_drive
+        self._code_server = code_server
         self._install_code()
         self._install_extensions()
         self._start_server()
         self._run_code()
 
-    def _install_code(self):
+    def _install_code(self):        
         subprocess.run(
             ["wget", "https://code-server.dev/install.sh"], stdout=subprocess.PIPE
         )
-        subprocess.run(["sh", "install.sh"], stdout=subprocess.PIPE)
+        if self._code_server = 'latest':
+            subprocess.run(["sh", "install.sh"], stdout=subprocess.PIPE)
+        else:
+            subprocess.run(["sh", "install.sh", "--version", str(self._code_server)], stdout=subprocess.PIPE)
+            
 
     def _install_extensions(self):
         for ext in EXTENSIONS:
@@ -61,4 +66,3 @@ class ColabCode:
         ) as proc:
             for line in proc.stdout:
                 print(line, end="")
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyngrok==4.1.12
+pyngrok>=5.0.0

--- a/scripts/colabcode
+++ b/scripts/colabcode
@@ -28,7 +28,14 @@ if __name__ == "__main__":
         action="store_true",
         help="if you use --mount_drive, your google drive will be mounted",
     )
+    optional.add_argument(
+        "--code_server",
+        action="store_true",
+        default="latest",
+        type=str
+        help="if you use --code_server, specify code server version in the format X.X.X",
+    )
 
     args = parser.parse_args()
 
-    ColabCode(port=args.port, password=args.password, mount_drive=args.mount_drive)
+    ColabCode(port=args.port, password=args.password, mount_drive=args.mount_drive, code_server=args.code_server)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
     setup(
         name="colabcode",
         scripts=["scripts/colabcode"],
-        version="0.1.0",
+        version="0.1.1",
         description="ColabCode - Run codeserver on Colab!",
         long_description=long_description,
         long_description_content_type="text/markdown",


### PR DESCRIPTION
Allows Users to specify code server version. For eg ver 3.7.1 for some reason breaks python extension while 3.6.0 doesn't.
- updated requirements.txt to pyngrok>=5.0.0 so that pip install requirements work (it was 4.something before).
- updated version from  0.1.0 -> 0.1.1
- works in shell version and as an import in the main class.
- updated readme.