### PR TITLE
Add Code Server parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,16 @@ usage: colabcode [-h] --port PORT [--password PASSWORD] [--mount_drive]
 ColabCode: Run VS Code On Colab / Kaggle Notebooks
 
 required arguments:
-  --port PORT          the port you want to run code-server on
+  --port PORT           the port you want to run code-server on
 
 optional arguments:
-  --password PASSWORD  password to protect your code-server from unauthorized access
-  --mount_drive        if you use --mount_drive, your google drive will be mounted
+  --password PASSWORD   password to protect your code-server from unauthorized access
+  --mount_drive         if you use --mount_drive, your google drive will be mounted
+  --user_data_dir USER_DATA_DIR
+                        Custom folder path for storing user related data
+  --extensions_dir EXTENSIONS_DIR
+                        Custom folder path for storing installed extentions
+  --config CONFIG       Custom file path for code-server config file
 ```
 
 Else, you can do the following:

--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -6,7 +6,6 @@ import nest_asyncio
 import uvicorn
 from pyngrok import ngrok
 
-
 try:
     from google.colab import drive
 
@@ -26,13 +25,19 @@ class ColabCode:
         password=None,
         authtoken=None,
         mount_drive=False,
+        user_data_dir=None,
+        config=None,
+        extensions_dir=None,
         code=True,
         lab=False,
     ):
         self.port = port
         self.password = password
         self.authtoken = authtoken
+        self._config = config
+        self._extensions_dir = extensions_dir
         self._mount = mount_drive
+        self._user_data_dir = user_data_dir
         self._code = code
         self._lab = lab
         if self._lab:
@@ -96,12 +101,23 @@ class ColabCode:
 
     def _run_code(self):
         os.system(f"fuser -n tcp -k {self.port}")
+        prefix = []
+        suffix = []
+        suffix.append(f"--port {self.port}")
+        suffix.append(f"--disable-telemetry")
+        code_cmd = "code-server "
         if self._mount and colab_env:
             drive.mount("/content/drive")
         if self.password:
-            code_cmd = f"PASSWORD={self.password} code-server --port {self.port} --disable-telemetry"
-        else:
-            code_cmd = f"code-server --port {self.port} --auth none --disable-telemetry"
+            prefix.append(f"PASSWORD={self.password} ")
+            suffix.append("--auth none")
+        if self._config:
+            suffix.append(f"--config {self._config}")
+        if self._extensions_dir:
+            suffix.append(f"--extensions-dir {self._extensions_dir}")
+        if self._user_data_dir:
+            suffix.append(f"--user-data-dir {self._user_data_dir}")
+        code_cmd = " ".join(prefix) + code_cmd + " ".join(suffix)
         with subprocess.Popen(
             [code_cmd],
             shell=True,

--- a/scripts/colabcode
+++ b/scripts/colabcode
@@ -30,7 +30,32 @@ if __name__ == "__main__":
         action="store_true",
         help="if you use --mount_drive, your google drive will be mounted",
     )
+    optional.add_argument(
+        "--user_data_dir",
+        type=str,
+        help="Custom folder path for storing user related data",
+        default=None,
+    )
+    optional.add_argument(
+        "--extensions_dir",
+        type=str,
+        help="Custom folder path for storing installed extentions",
+        default=None,
+    )
+    optional.add_argument(
+        "--config",
+        type=str,
+        help="Custom file path for code-server config file",
+        default=None,
+    )
 
     args = parser.parse_args()
 
-    ColabCode(port=args.port, password=args.password, mount_drive=args.mount_drive)
+    ColabCode(
+        port=args.port,
+        password=args.password,
+        mount_drive=args.mount_drive,
+        user_data_dir=args.user_data_dir,
+        extensions_dir=args.extensions_dir,
+        config=args.config,
+    )


### PR DESCRIPTION
This update allows users to set their paths for code-server configuration to keep their extension and user settings stored  in custom folders (preferably in a Google Drive folder). Each time connection is restarted, all the configuration will be loaded back.

```python
#Example Usage
ColabCode(
        port=10000,
        password="pass",
        mount_drive=True,
        user_data_dir="MyDrivePath/user_data",
        extensions_dir="MyDrivePath/extensions",
        config="MyDrivePath/config.yaml",
    )
```