### PR TITLE
pass protocol for ngrok connect

### DIFF
--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -48,7 +48,8 @@ class ColabCode:
     def _install_code():
         subprocess.run(["wget", "https://code-server.dev/install.sh"], stdout=subprocess.PIPE)
         subprocess.run(
-            ["sh", "install.sh", "--version", f"{CODESERVER_VERSION}"],
+            # ["sh", "install.sh", "--version", f"{CODESERVER_VERSION}"],
+            ["sh", "install.sh"],
             stdout=subprocess.PIPE,
         )
 

--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -23,6 +23,7 @@ class ColabCode:
     def __init__(
         self,
         port=10000,
+        proto="http",
         password=None,
         authtoken=None,
         mount_drive=False,
@@ -30,6 +31,7 @@ class ColabCode:
         lab=False,
     ):
         self.port = port
+        self.proto = proto
         self.password = password
         self.authtoken = authtoken
         self._mount = mount_drive
@@ -64,7 +66,7 @@ class ColabCode:
         for tunnel in active_tunnels:
             public_url = tunnel.public_url
             ngrok.disconnect(public_url)
-        url = ngrok.connect(addr=self.port, bind_tls=True)
+        url = ngrok.connect(addr=self.port, proto=self.proto, bind_tls=True)
         if self._code:
             print(f"Code Server can be accessed on: {url}")
         else:

--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -48,12 +48,13 @@ class ColabCode:
 
     @staticmethod
     def _install_code():
-        subprocess.run(["wget", "https://code-server.dev/install.sh"], stdout=subprocess.PIPE)
-        subprocess.run(
-            # ["sh", "install.sh", "--version", f"{CODESERVER_VERSION}"],
-            ["sh", "install.sh"],
-            stdout=subprocess.PIPE,
-        )
+        result = subprocess.run(["wget", "https://code-server.dev/install.sh"], stdout=subprocess.PIPE)
+        if result.returncode != 0:
+            raise RuntimeError("Failed to download installation script")
+            
+        result = subprocess.run(["sh", "install.sh"], stdout=subprocess.PIPE)
+        if result.returncode != 0:
+            raise RuntimeError("Failed to run installation script")
 
     @staticmethod
     def _install_extensions():

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from setuptools import Extension, find_packages, setup
+
+
+with open("README.md") as f:
+    long_description = f.read()
+
+
+if __name__ == "__main__":
+    setup(
+        name="colabcode",
+        scripts=["scripts/colabcode"],
+        version="0.3.0",
+        description="ColabCode - Run codeserver on Colab!",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        author="Abhishek Thakur",
+        author_email="abhishek4@gmail.com",
+        url="https://github.com/abhishekkrthakur/colabcode",
+        license="MIT License",
+        packages=find_packages(),
+        include_package_data=True,
+        install_requires=[
+            "pyngrok>=5.0.0",
+            "nest_asyncio==1.4.3",
+            "uvicorn==0.13.1",
+            "jupyterlab==3.0.7",
+        ],
+        platforms=["linux", "unix"],
+        python_requires=">3.5.2",
+    )

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ if __name__ == "__main__":
         include_package_data=True,
         install_requires=[
             "pyngrok>=5.0.0",
-            "nest_asyncio==1.4.3",
-            "uvicorn==0.13.1",
-            "jupyterlab==3.0.7",
+            "nest_asyncio>=1.4.3",
+            "uvicorn>=0.13.1",
+            "jupyterlab>=3.0.7",
         ],
         platforms=["linux", "unix"],
         python_requires=">3.5.2",


### PR DESCRIPTION
Without mentioning the protocol, this error is encountered.

```bash
PyngrokNgrokHTTPError: ngrok client exception, API returned 400: {"error_code":102,"status_code":400,"msg":"invalid tunnel configuration","details":{"err":"yaml: unmarshal errors:\n  line 1: field options not found in type config.HTTPv2Tunnel"}}
```

package versions:
```
ngrok version 3.23.1
pyngrok version 7.2.11
```